### PR TITLE
Remove all unsafe code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
  "tokio",
  "uuid",
  "xal",
+ "zerocopy",
 ]
 
 [[package]]

--- a/xodus/Cargo.toml
+++ b/xodus/Cargo.toml
@@ -19,3 +19,4 @@ uuid = "1.23.1"
 aes = "0.9.0"
 keyring-core = "1.0.0"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-openssl"]}
+zerocopy = { version = "0.8.48", features = ["derive"] }

--- a/xodus/src/clep/challenge.rs
+++ b/xodus/src/clep/challenge.rs
@@ -1,21 +1,22 @@
 use crate::models::clep::*;
-use std::mem::{transmute, zeroed};
+
+use zerocopy::{FromZeros, transmute};
 
 pub fn get_license_challange(smbios: [u8; 256], disk_serial: [u8; 64]) -> ([u8; 2048], [u8; 2048]) {
-    let mut clepv2: ClepV2 = unsafe { zeroed() };
+    let mut clepv2 = ClepV2::new_zeroed();
     clepv2.version = 2;
     clepv2.always_0 = 0;
     clepv2.always_1 = true;
     clepv2.smbios.copy_from_slice(&smbios);
     clepv2.disk_serial.copy_from_slice(&disk_serial);
-    let mut clepv4: ClepV4 = unsafe { zeroed() };
+    let mut clepv4 = ClepV4::new_zeroed();
     clepv4.version = 4;
     clepv4.debuger_not_present = 1;
     clepv4.smbios = smbios;
     clepv4.disk_serial = disk_serial;
 
-    let mut obfuscatedv2 = unsafe { transmute(clepv2) };
-    let mut obfuscatedv4 = unsafe { transmute(clepv4) };
+    let mut obfuscatedv2 = transmute!(clepv2);
+    let mut obfuscatedv4 = transmute!(clepv4);
 
     clep_obfuscate(&mut obfuscatedv2);
     clep_obfuscate(&mut obfuscatedv4);

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -24,6 +24,7 @@
 use std::io::{BufRead, BufReader, Read};
 
 use aes::cipher::{BlockCipherDecrypt, KeyInit};
+use zerocopy::transmute;
 
 // pub struct Block<'a> {
 //     pub block_id: BlockId,
@@ -262,7 +263,7 @@ impl From<&[u8]> for SPLicense {
 
 pub fn derive_device_key(license: &[u8]) -> Vec<u8> {
     let keyschedule: [u8; 228] = license[4..232].try_into().unwrap();
-    let keyschedule: [u32; 57] = unsafe { std::mem::transmute(keyschedule) };
+    let keyschedule: [u32; 57] = transmute!(keyschedule);
     let devicekey: [u8; 16] = license[516..532].try_into().unwrap();
 
     let mut decryption_key = [0u32; 4];
@@ -271,7 +272,7 @@ pub fn derive_device_key(license: &[u8]) -> Vec<u8> {
     decryption_key[1] = keyschedule[36] ^ keyschedule[47] ^ 0xDF080E39;
     decryption_key[2] = keyschedule[40] ^ keyschedule[51] ^ 0x6D09B2F5 ^ 0x2AE17AB9;
     decryption_key[3] = keyschedule[30] ^ keyschedule[41] ^ 0x37288CEC;
-    let decryption_key: [u8; 16] = unsafe { std::mem::transmute(decryption_key) };
+    let decryption_key: [u8; 16] = transmute!(decryption_key);
 
     let key = aes::cipher::array::Array::from(decryption_key);
     let aes = aes::Aes128::new(&key);

--- a/xodus/src/models/clep.rs
+++ b/xodus/src/models/clep.rs
@@ -1,3 +1,6 @@
+use zerocopy::{FromZeros, IntoBytes};
+
+#[derive(FromZeros, IntoBytes)]
 #[repr(C, packed)]
 pub struct ClepV2 {
     pub version: u32,
@@ -11,6 +14,7 @@ pub struct ClepV2 {
     pub reserved: [u8; 639],
 }
 
+#[derive(FromZeros, IntoBytes)]
 #[repr(C, packed)]
 pub struct ClepV4 {
     pub version: u32,


### PR DESCRIPTION
Replace unsafe transmutes with zerocopy's safe transmute macro, which checks that the transmute is safe at compile time. Zerocopy was already being pulled as a dependency, so adding it directly to Xodus doesn't have any drawback.