### PR TITLE
Clep obfuscation cleanup

### DIFF
--- a/xodus/src/clep/challenge.rs
+++ b/xodus/src/clep/challenge.rs
@@ -1,6 +1,6 @@
 use crate::models::clep::*;
 
-use zerocopy::{FromZeros, transmute};
+use zerocopy::{FromZeros, transmute, transmute_mut};
 
 pub fn get_license_challange(smbios: [u8; 256], disk_serial: [u8; 64]) -> ([u8; 2048], [u8; 2048]) {
     let mut clepv2 = ClepV2::new_zeroed();
@@ -34,59 +34,58 @@ const MAGIC_02: u32 = MAGIC_HI << 16 >> 16; // 0x1621
 const MAGIC_03: u32 = MAGIC_LO >> 16; // 0x4139
 const MAGIC_04: u32 = MAGIC_LO << 16 >> 16; // 0x3243
 
-/// Custom Feistel cipher used by CLEP to obfuscate the challenge request buffer.
-///
-/// Operates in a CBC-like mode on 8-byte blocks over the 2044-byte data region
-/// (skipping the 4-byte version header)
-pub fn clep_obfuscate(buffer: &mut [u8; 2048]) {
-    // --- Key schedule: derive initial cipher state from hardcoded constants ---
-    let k0 = !(MAGIC_03.wrapping_mul(MAGIC_HI.rotate_right(10)));
-    let k1 = MAGIC_04
-        .wrapping_mul((k0 ^ MAGIC_HI).rotate_right(22))
-        .wrapping_sub(k0.rotate_right(8));
-    let k2 = k0 ^ MAGIC_04.wrapping_mul(k1.rotate_right(15) ^ MAGIC_01);
-    let k3 = k1 ^ (k2 >> 9).wrapping_add(MAGIC_02.wrapping_mul((k2 ^ MAGIC_03).rotate_left(3)));
-    let k4 = k2 ^ k3.rotate_right(28) ^ MAGIC_03.wrapping_mul((k3 ^ MAGIC_HI).rotate_right(9));
-    let k5 = k3
-        ^ k4.rotate_right(12)
-            .wrapping_add(MAGIC_04.wrapping_mul(k4.wrapping_sub(MAGIC_HI).rotate_right(14)));
-    let k6 = k4 ^ k5.rotate_right(11) ^ MAGIC_01.wrapping_mul((k5 ^ MAGIC_02).rotate_left(2));
-    let k7 = k5 ^ k6.wrapping_sub(MAGIC_LO).wrapping_sub(MAGIC_02);
-    let k8 = k6
-        ^ MAGIC_03
-            .wrapping_mul((k7 ^ MAGIC_01).rotate_left(2))
-            .wrapping_sub(k7.rotate_right(18));
-    // let k9 = MAGIC_04
-    //     .wrapping_mul(k8.wrapping_sub(MAGIC_HI).rotate_right(18))
-    //     .wrapping_sub(k8.rotate_right(9));
+struct Cipher {
+    lo: u32,
+    hi: u32,
 
-    // Initial cipher state (two 32-bit halves)
-    let mut state_lo: u32 = k8;
-    // let mut state_hi: u32 = k7 ^ k9;
+    plain: u64,
+}
 
-    // --- IV setup: XOR state with first data word, write back ---
-    let iv = u32::from_le_bytes(buffer[4..8].try_into().unwrap());
-    state_lo ^= iv;
-    // state_hi = 0; // high half of IV is zero
+impl Cipher {
+    const INITIAL_STATE: u32 = Cipher::initial_state();
 
-    buffer[4..8].copy_from_slice(&state_lo.to_le_bytes());
+    const fn initial_state() -> u32 {
+        // --- Key schedule: derive initial cipher state from hardcoded constants ---
+        let k0 = !(MAGIC_03.wrapping_mul(MAGIC_HI.rotate_right(10)));
+        let k1 = MAGIC_04
+            .wrapping_mul((k0 ^ MAGIC_HI).rotate_right(22))
+            .wrapping_sub(k0.rotate_right(8));
+        let k2 = k0 ^ MAGIC_04.wrapping_mul(k1.rotate_right(15) ^ MAGIC_01);
+        let k3 = k1 ^ (k2 >> 9).wrapping_add(MAGIC_02.wrapping_mul((k2 ^ MAGIC_03).rotate_left(3)));
+        let k4 = k2 ^ k3.rotate_right(28) ^ MAGIC_03.wrapping_mul((k3 ^ MAGIC_HI).rotate_right(9));
+        let k5 = k3
+            ^ k4.rotate_right(12)
+                .wrapping_add(MAGIC_04.wrapping_mul(k4.wrapping_sub(MAGIC_HI).rotate_right(14)));
+        let k6 = k4 ^ k5.rotate_right(11) ^ MAGIC_01.wrapping_mul((k5 ^ MAGIC_02).rotate_left(2));
+        let k7 = k5 ^ k6.wrapping_sub(MAGIC_LO).wrapping_sub(MAGIC_02);
+        let k8 = k6
+            ^ MAGIC_03
+                .wrapping_mul((k7 ^ MAGIC_01).rotate_left(2))
+                .wrapping_sub(k7.rotate_right(18));
+        // let k9 = MAGIC_04
+        //    .wrapping_mul(k8.wrapping_sub(MAGIC_HI).rotate_right(18))
+        //    .wrapping_sub(k8.rotate_right(9));
 
-    // --- CBC-like encryption of 255 blocks (buffer[8..2048]) ---
-    let mut prev_lo = state_lo;
-    let mut prev_hi: u32 = 0;
-    let mut prev_plain: u64 = iv as u64;
+        k8
+    }
 
-    for i in 0..255usize {
-        let off = 8 + i * 8;
-        let block = u64::from_le_bytes(buffer[off..off + 8].try_into().unwrap());
+    pub const fn new(iv: u32) -> Self {
+        Self {
+            lo: Self::INITIAL_STATE ^ iv,
+            hi: 0,
+            plain: iv as u64,
+        }
+    }
+
+    const fn encrypt_int(&mut self, block: u64) -> u64 {
         let block_lo = block as u32;
         let block_hi = (block >> 32) as u32;
-        let pp_lo = prev_plain as u32;
-        let pp_hi = (prev_plain >> 32) as u32;
+        let pp_lo = self.plain as u32;
+        let pp_hi = (self.plain >> 32) as u32;
 
         // 10 Feistel rounds
-        let r0 = prev_lo ^ block_lo;
-        let r1 = prev_hi
+        let r0 = self.lo ^ block_lo;
+        let r1 = self.hi
             ^ block_hi
             ^ MAGIC_04
                 .wrapping_mul(r0.wrapping_sub(MAGIC_HI).rotate_right(18))
@@ -116,12 +115,39 @@ pub fn clep_obfuscate(buffer: &mut [u8; 2048]) {
                 .wrapping_sub(r9.rotate_right(29));
         let new_hi = r9 ^ pp_hi;
 
-        buffer[off..off + 4].copy_from_slice(&new_lo.to_le_bytes());
-        buffer[off + 4..off + 8].copy_from_slice(&new_hi.to_le_bytes());
+        // Update cipher state
+        self.lo = new_lo;
+        self.hi = new_hi;
+        self.plain = block;
 
-        prev_lo = new_lo;
-        prev_hi = new_hi;
-        prev_plain = block;
+        // Return the encrypted int by joining the new low and high
+        (new_lo as u64) | ((new_hi as u64) << 32)
+    }
+
+    pub const fn encrypt_block(&mut self, block: &mut [u8; 8]) {
+        let block_num = u64::from_le_bytes(*block);
+        let encrypted = self.encrypt_int(block_num);
+        *block = encrypted.to_le_bytes();
+    }
+}
+
+/// Custom Feistel cipher used by CLEP to obfuscate the challenge request buffer.
+///
+/// Operates in a CBC-like mode on 8-byte blocks over the 2044-byte data region
+/// (skipping the 4-byte version header)
+pub fn clep_obfuscate(buffer: &mut [u8; 2048]) {
+    // --- IV setup: XOR state with first data word, write back ---
+    let blocks: &mut [[u8; 8]; 256] = transmute_mut!(buffer);
+    let [_word1, word2]: &mut [[u8; 4]; 2] = transmute_mut!(&mut blocks[0]);
+
+    let iv = u32::from_le_bytes(*word2);
+    let mut cipher = Cipher::new(iv);
+
+    *word2 = cipher.lo.to_le_bytes();
+
+    // --- CBC-like encryption of 255 blocks (buffer[8..2048]) ---
+    for block in blocks.iter_mut().skip(1) {
+        cipher.encrypt_block(block);
     }
 }
 

--- a/xodus/src/clep/challenge.rs
+++ b/xodus/src/clep/challenge.rs
@@ -24,16 +24,6 @@ pub fn get_license_challange(smbios: [u8; 256], disk_serial: [u8; 64]) -> ([u8; 
     return (obfuscatedv2, obfuscatedv4);
 }
 
-const MAGIC: u64 = 0x2418_1621_4139_3243;
-
-const MAGIC_LO: u32 = MAGIC as u32; // 0x41393243
-const MAGIC_HI: u32 = (MAGIC >> 32) as u32; // 0x24181621
-
-const MAGIC_01: u32 = MAGIC_HI >> 16; // 0x2418
-const MAGIC_02: u32 = MAGIC_HI << 16 >> 16; // 0x1621
-const MAGIC_03: u32 = MAGIC_LO >> 16; // 0x4139
-const MAGIC_04: u32 = MAGIC_LO << 16 >> 16; // 0x3243
-
 struct Cipher {
     lo: u32,
     hi: u32,
@@ -42,28 +32,45 @@ struct Cipher {
 }
 
 impl Cipher {
+    const MAGIC: u64 = 0x2418_1621_4139_3243;
+
+    const MAGIC_LO: u32 = Self::MAGIC as u32; // 0x41393243
+    const MAGIC_HI: u32 = (Self::MAGIC >> 32) as u32; // 0x24181621
+
+    const MAGIC_01: u32 = Self::MAGIC_HI >> 16; // 0x2418
+    const MAGIC_02: u32 = Self::MAGIC_HI << 16 >> 16; // 0x1621
+    const MAGIC_03: u32 = Self::MAGIC_LO >> 16; // 0x4139
+    const MAGIC_04: u32 = Self::MAGIC_LO << 16 >> 16; // 0x3243
+
     const INITIAL_STATE: u32 = Cipher::initial_state();
 
     const fn initial_state() -> u32 {
         // --- Key schedule: derive initial cipher state from hardcoded constants ---
-        let k0 = !(MAGIC_03.wrapping_mul(MAGIC_HI.rotate_right(10)));
-        let k1 = MAGIC_04
-            .wrapping_mul((k0 ^ MAGIC_HI).rotate_right(22))
+        let k0 = !(Self::MAGIC_03.wrapping_mul(Self::MAGIC_HI.rotate_right(10)));
+        let k1 = Self::MAGIC_04
+            .wrapping_mul((k0 ^ Self::MAGIC_HI).rotate_right(22))
             .wrapping_sub(k0.rotate_right(8));
-        let k2 = k0 ^ MAGIC_04.wrapping_mul(k1.rotate_right(15) ^ MAGIC_01);
-        let k3 = k1 ^ (k2 >> 9).wrapping_add(MAGIC_02.wrapping_mul((k2 ^ MAGIC_03).rotate_left(3)));
-        let k4 = k2 ^ k3.rotate_right(28) ^ MAGIC_03.wrapping_mul((k3 ^ MAGIC_HI).rotate_right(9));
+        let k2 = k0 ^ Self::MAGIC_04.wrapping_mul(k1.rotate_right(15) ^ Self::MAGIC_01);
+        let k3 = k1
+            ^ (k2 >> 9)
+                .wrapping_add(Self::MAGIC_02.wrapping_mul((k2 ^ Self::MAGIC_03).rotate_left(3)));
+        let k4 = k2
+            ^ k3.rotate_right(28)
+            ^ Self::MAGIC_03.wrapping_mul((k3 ^ Self::MAGIC_HI).rotate_right(9));
         let k5 = k3
-            ^ k4.rotate_right(12)
-                .wrapping_add(MAGIC_04.wrapping_mul(k4.wrapping_sub(MAGIC_HI).rotate_right(14)));
-        let k6 = k4 ^ k5.rotate_right(11) ^ MAGIC_01.wrapping_mul((k5 ^ MAGIC_02).rotate_left(2));
-        let k7 = k5 ^ k6.wrapping_sub(MAGIC_LO).wrapping_sub(MAGIC_02);
+            ^ k4.rotate_right(12).wrapping_add(
+                Self::MAGIC_04.wrapping_mul(k4.wrapping_sub(Self::MAGIC_HI).rotate_right(14)),
+            );
+        let k6 = k4
+            ^ k5.rotate_right(11)
+            ^ Self::MAGIC_01.wrapping_mul((k5 ^ Self::MAGIC_02).rotate_left(2));
+        let k7 = k5 ^ k6.wrapping_sub(Self::MAGIC_LO).wrapping_sub(Self::MAGIC_02);
         let k8 = k6
-            ^ MAGIC_03
-                .wrapping_mul((k7 ^ MAGIC_01).rotate_left(2))
+            ^ Self::MAGIC_03
+                .wrapping_mul((k7 ^ Self::MAGIC_01).rotate_left(2))
                 .wrapping_sub(k7.rotate_right(18));
-        // let k9 = MAGIC_04
-        //    .wrapping_mul(k8.wrapping_sub(MAGIC_HI).rotate_right(18))
+        // let k9 = Self::MAGIC_04
+        //    .wrapping_mul(k8.wrapping_sub(Self::MAGIC_HI).rotate_right(18))
         //    .wrapping_sub(k8.rotate_right(9));
 
         k8
@@ -87,31 +94,38 @@ impl Cipher {
         let r0 = self.lo ^ block_lo;
         let r1 = self.hi
             ^ block_hi
-            ^ MAGIC_04
-                .wrapping_mul(r0.wrapping_sub(MAGIC_HI).rotate_right(18))
+            ^ Self::MAGIC_04
+                .wrapping_mul(r0.wrapping_sub(Self::MAGIC_HI).rotate_right(18))
                 .wrapping_sub(r0.rotate_right(9));
         let r2 = r0
-            ^ MAGIC_03
-                .wrapping_mul((r1 ^ MAGIC_01).rotate_left(2))
+            ^ Self::MAGIC_03
+                .wrapping_mul((r1 ^ Self::MAGIC_01).rotate_left(2))
                 .wrapping_sub(r1.rotate_right(18));
-        let r3 = r1 ^ r2.wrapping_sub(MAGIC_02).wrapping_sub(MAGIC_LO);
-        let r4 = r2 ^ r3.rotate_right(11) ^ MAGIC_01.wrapping_mul((r3 ^ MAGIC_02).rotate_left(2));
+        let r3 = r1 ^ r2.wrapping_sub(Self::MAGIC_02).wrapping_sub(Self::MAGIC_LO);
+        let r4 = r2
+            ^ r3.rotate_right(11)
+            ^ Self::MAGIC_01.wrapping_mul((r3 ^ Self::MAGIC_02).rotate_left(2));
         let r5 = r3
-            ^ r4.rotate_right(12)
-                .wrapping_add(MAGIC_04.wrapping_mul(r4.wrapping_sub(MAGIC_HI).rotate_right(14)));
-        let r6 = r4 ^ r5.rotate_right(28) ^ MAGIC_03.wrapping_mul((r5 ^ MAGIC_HI).rotate_right(9));
-        let r7 = r5 ^ (r6 >> 9).wrapping_add(MAGIC_02.wrapping_mul((r6 ^ MAGIC_03).rotate_left(3)));
-        let r8 = r6 ^ MAGIC_04.wrapping_mul(r7.rotate_right(15) ^ MAGIC_01);
+            ^ r4.rotate_right(12).wrapping_add(
+                Self::MAGIC_04.wrapping_mul(r4.wrapping_sub(Self::MAGIC_HI).rotate_right(14)),
+            );
+        let r6 = r4
+            ^ r5.rotate_right(28)
+            ^ Self::MAGIC_03.wrapping_mul((r5 ^ Self::MAGIC_HI).rotate_right(9));
+        let r7 = r5
+            ^ (r6 >> 9)
+                .wrapping_add(Self::MAGIC_02.wrapping_mul((r6 ^ Self::MAGIC_03).rotate_left(3)));
+        let r8 = r6 ^ Self::MAGIC_04.wrapping_mul(r7.rotate_right(15) ^ Self::MAGIC_01);
         let r9 = r7
-            ^ MAGIC_04
-                .wrapping_mul((r8 ^ MAGIC_HI).rotate_right(22))
+            ^ Self::MAGIC_04
+                .wrapping_mul((r8 ^ Self::MAGIC_HI).rotate_right(22))
                 .wrapping_sub(r8.rotate_right(8));
 
         // Output with CBC-like plaintext feedback
         let new_lo = pp_lo
             ^ r8
-            ^ MAGIC_03
-                .wrapping_mul(r9.wrapping_add(MAGIC_HI).rotate_right(10))
+            ^ Self::MAGIC_03
+                .wrapping_mul(r9.wrapping_add(Self::MAGIC_HI).rotate_right(10))
                 .wrapping_sub(r9.rotate_right(29));
         let new_hi = r9 ^ pp_hi;
 


### PR DESCRIPTION
Split the existing `clep_obfuscate` function into smaller pieces. Add a new `Cipher` struct in `clep::challenge` that stores the cipher state, and add associated functions to it that encrypt and update the internal state.

I tried to simplify the `clep_obfuscate` function because it did a lot of things in one single place. Now the function creates a new `Cipher` struct by obtaining the correct IV from the buffer and encrypts/obfuscates each block in place. Also, the `Cipher` struct now stores `Cipher::INITIAL_STATE` as a constant. It is being calculated with the same method as before, just in a separate const function.

I think overall the code is more readable now.

I tested a few examples of encrypting buffers with the old and new code and it produces the same exact outputs.