### PR TITLE
fix: use neutral market as default for license command

### DIFF
--- a/xodus-cli/src/main.rs
+++ b/xodus-cli/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
             dry_run,
         } => (),//commands::download::run(&client, product, market, dry_run).await,
         SubCommand::License { content_id, market } => {
-            commands::license::run(&client, content_id, market.unwrap_or("en-US".to_string()))
+            commands::license::run(&client, content_id, market.unwrap_or("neutral".to_string()))
                 .await;
         }
         SubCommand::Login => {


### PR DESCRIPTION
`en-US` does not return any response, only a country code like `US` or `neutral`