### PR TITLE
fix: Call save_token in license.is_err() case

### DIFF
--- a/xodus-cli/src/device.rs
+++ b/xodus-cli/src/device.rs
@@ -58,9 +58,6 @@ pub async fn ensure_device_credentials(client: &reqwest::Client) {
             let key_name = key_name.clone();
             let token: xodus::models::secrets::Token = resp.into();
             save_token(key_name, token);
-            let entry = xodus::secrets::get_entry("device-STS").unwrap();
-            let json = serde_json::to_string(&token).unwrap();
-            entry.set_secret(json.as_bytes()).unwrap();
         }
     } else if get_device_token().is_err() {
         let license = license.unwrap();

--- a/xodus-cli/src/device.rs
+++ b/xodus-cli/src/device.rs
@@ -46,7 +46,18 @@ pub async fn ensure_device_credentials(client: &reqwest::Client) {
             .expect("Failed to auth device");
 
         if let BodyContent::RequestSecurityTokenResponse(resp) = tokens.body.body {
+            let key_name = resp
+                .requested_security_token
+                .encrypted_data
+                .as_ref()
+                .unwrap()
+                .key_info
+                .key_name
+                .as_ref()
+                .unwrap();
+            let key_name = key_name.clone();
             let token: xodus::models::secrets::Token = resp.into();
+            save_token(key_name, token);
             let entry = xodus::secrets::get_entry("device-STS").unwrap();
             let json = serde_json::to_string(&token).unwrap();
             entry.set_secret(json.as_bytes()).unwrap();


### PR DESCRIPTION
* on my end this had caused ensure_device_credentials to not populate the required secret