### PR TITLE
fix: read nonce from res_envelope

### DIFF
--- a/xodus/src/api/live/mod.rs
+++ b/xodus/src/api/live/mod.rs
@@ -203,9 +203,9 @@ pub async fn exchange_device_token(
 
     let res_envelope: soap::Envelope = quick_xml::de::from_str(&text).expect("Failed to de xml");
     let mut nonce = None;
-    for token in envelope.header.security.derived_key_tokens {
+    for token in &res_envelope.header.security.derived_key_tokens {
         if token.id == "SignKey" {
-            nonce = Some(token.nonce);
+            nonce = Some(token.nonce.clone());
             continue;
         }
     }


### PR DESCRIPTION
I actually wanted to return a signature error, but reqwest::Error is not createable and a custom error supporting both needs so much rust code...

Posting this so I do not forget this.