### PR TITLE
Add custom error enums in splicense

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "url",
  "uuid",

--- a/xodus-cli/src/commands/license.rs
+++ b/xodus-cli/src/commands/license.rs
@@ -1,7 +1,7 @@
 use crate::{device, user};
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 use xodus::{
-    licensing::splicense::{parse_license, unpack_key},
+    licensing::splicense::{SPLicense, unpack_key},
     models::{live::ExchangeUserTokenOutcome, secrets::Token, soap},
 };
 
@@ -86,10 +86,10 @@ pub async fn run(client: &reqwest::Client, content_id: String, market: String, c
     .await
     .expect("failed to get license");
 
-    let game_splicense = parse_license(game_license.splicense_block);
+    let game_splicense = SPLicense::parse_base64(game_license.splicense_block).unwrap();
 
     let dev_license = device::get_dev_license().unwrap();
-    let device_license = parse_license(dev_license.splicense);
+    let device_license = SPLicense::parse_base64(dev_license.splicense).unwrap();
     let key = device_license
         .encrypted_device_key
         .unwrap()

--- a/xodus-cli/src/license.rs
+++ b/xodus-cli/src/license.rs
@@ -84,10 +84,12 @@ pub async fn get_license(
     .await
     .expect("failed to get license");
 
-    let game_splicense = SPLicense::parse_base64(game_license.splicense_block).unwrap();
+    let game_splicense = SPLicense::parse_base64(game_license.splicense_block)
+        .expect("could not parse base64 game SPLicense");
 
     let dev_license = device::get_dev_license().unwrap();
-    let device_license = SPLicense::parse_base64(dev_license.splicense).unwrap();
+    let device_license = SPLicense::parse_base64(dev_license.splicense)
+        .expect("could not parse base64 device SPLicense");
     let key = device_license
         .encrypted_device_key
         .unwrap()

--- a/xodus/Cargo.toml
+++ b/xodus/Cargo.toml
@@ -28,6 +28,7 @@ cbc = "0.2.1"
 url = "2.5.8"
 aes-keywrap = "0.9.0"
 num_enum = "0.7.6"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 rsa = "0.9.10"

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -126,6 +126,9 @@ fn read_vec<R: Read>(mut reader: R, len: usize) -> io::Result<Vec<u8>> {
 pub enum DecodeError {
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),
+
+    #[error("expected to read {expected} bytes but only {read} were read")]
+    PayloadLengthMismatch { expected: usize, read: usize },
 }
 
 impl SPLicense {
@@ -150,6 +153,9 @@ impl SPLicense {
         };
 
         let size = read_u32(&mut reader)? as usize;
+
+        // Create a new reader that limits the number of bytes that can be read to `size`
+        let mut reader = reader.take(size as u64);
 
         match block_id {
             Ok(BlockId::LicenseId) => {
@@ -245,6 +251,14 @@ impl SPLicense {
             _ => {
                 let _unknown = read_vec(&mut reader, size)?;
             }
+        }
+
+        // Ensure the number of bytes read is exactly `size`
+        if reader.limit() != 0 {
+            return Err(DecodeError::PayloadLengthMismatch {
+                expected: size,
+                read: size - reader.limit() as usize,
+            });
         }
 
         Ok(Some(()))

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -307,8 +307,18 @@ impl EncryptedDeviceKey {
     }
 }
 
-pub fn parse_license(splicense_block: String) -> SPLicense {
-    SPLicense::decode(BASE64_STANDARD.decode(splicense_block).unwrap().as_slice()).unwrap()
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("SPLicense decode error: {0}")]
+    DecodeError(#[from] DecodeError),
+
+    #[error("could not decode base64 string: {0}")]
+    PayloadLengthMismatch(#[from] base64::DecodeError),
+}
+
+pub fn parse_license(splicense_block: String) -> Result<SPLicense, ParseError> {
+    let data = BASE64_STANDARD.decode(splicense_block)?;
+    Ok(SPLicense::decode(&*data)?)
 }
 
 pub fn unpack_key(

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -26,6 +26,7 @@ use std::{collections::HashMap, io, io::Read};
 use aes::cipher::{BlockCipherDecrypt, KeyInit};
 use base64::prelude::*;
 use num_enum::TryFromPrimitive;
+use thiserror::Error;
 use zerocopy::{FromBytes, IntoBytes, transmute};
 
 // pub struct Block<'a> {
@@ -121,11 +122,17 @@ fn read_vec<R: Read>(mut reader: R, len: usize) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("IO error: {0}")]
+    IoError(#[from] io::Error),
+}
+
 impl SPLicense {
     /// Merges a tag-length-value from the `reader` into this [`SPLicense`].
     ///
     /// Returns None if there are none TLVs left in the reader.
-    fn merge_tlv<R: Read>(&mut self, mut reader: R) -> io::Result<Option<()>> {
+    fn merge_tlv<R: Read>(&mut self, mut reader: R) -> Result<Option<()>, DecodeError> {
         let mut buffer = [0u8; 4];
 
         // Doesn't use read_u32 to allow checking for EOF without error
@@ -243,7 +250,7 @@ impl SPLicense {
         Ok(Some(()))
     }
 
-    pub fn decode<R: Read>(mut reader: R) -> io::Result<Self> {
+    pub fn decode<R: Read>(mut reader: R) -> Result<Self, DecodeError> {
         // Decode the header
         let _header: [u8; 4] = read_array(&mut reader)?;
         let _offset = read_u32(&mut reader)?;

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -131,6 +131,15 @@ pub enum DecodeError {
     PayloadLengthMismatch { expected: usize, read: usize },
 }
 
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("SPLicense decode error: {0}")]
+    DecodeError(#[from] DecodeError),
+
+    #[error("could not decode base64 string: {0}")]
+    PayloadLengthMismatch(#[from] base64::DecodeError),
+}
+
 impl SPLicense {
     /// Merges a tag-length-value from the `reader` into this [`SPLicense`].
     ///
@@ -277,6 +286,11 @@ impl SPLicense {
 
         Ok(license)
     }
+
+    pub fn parse_base64(string: String) -> Result<SPLicense, ParseError> {
+        let data = BASE64_STANDARD.decode(string)?;
+        Ok(SPLicense::decode(&*data)?)
+    }
 }
 
 impl EncryptedDeviceKey {
@@ -305,20 +319,6 @@ impl EncryptedDeviceKey {
 
         device_key.0
     }
-}
-
-#[derive(Debug, Error)]
-pub enum ParseError {
-    #[error("SPLicense decode error: {0}")]
-    DecodeError(#[from] DecodeError),
-
-    #[error("could not decode base64 string: {0}")]
-    PayloadLengthMismatch(#[from] base64::DecodeError),
-}
-
-pub fn parse_license(splicense_block: String) -> Result<SPLicense, ParseError> {
-    let data = BASE64_STANDARD.decode(splicense_block)?;
-    Ok(SPLicense::decode(&*data)?)
 }
 
 pub fn unpack_key(


### PR DESCRIPTION
Add custom error enums using the `thiserror` crate.