### PR TITLE
Add more Splicense structs

### DIFF
--- a/xodus-cli/src/commands/extract.rs
+++ b/xodus-cli/src/commands/extract.rs
@@ -1,7 +1,4 @@
-use xodus::{
-    licensing::splicense::unpack_key,
-    xvd::utils::{parse_file, unpack_file},
-};
+use xodus::xvd::utils::{parse_file, unpack_file};
 
 use crate::license::get_license;
 pub async fn run(
@@ -25,13 +22,7 @@ pub async fn run(
         )
     }
     if let Some((_, content_key)) = game_splicense.content_keys.into_iter().next() {
-        let unpacked: Vec<u8> = unpack_key(&key, content_key).expect("failed to unpack");
-        unpack_file(
-            xvd,
-            path.to_string(),
-            destination.to_string(),
-            unpacked.try_into().expect("match"),
-        )
-        .expect("unpack ok");
+        let unpacked = content_key.unpack(&key).expect("failed to unpack");
+        unpack_file(xvd, path.to_string(), destination.to_string(), unpacked).expect("unpack ok");
     }
 }

--- a/xodus-cli/src/commands/license.rs
+++ b/xodus-cli/src/commands/license.rs
@@ -1,6 +1,5 @@
 use crate::license::get_license;
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
-use xodus::licensing::splicense::unpack_key;
 
 pub async fn run(client: &reqwest::Client, content_id: String, market: String, ciks: String) {
     let license = get_license(client, content_id, market).await;
@@ -12,7 +11,7 @@ pub async fn run(client: &reqwest::Client, content_id: String, market: String, c
     let (key, game_splicense) = license.unwrap();
     tokio::fs::create_dir_all(&ciks).await.unwrap();
     for (uuid, content_key) in game_splicense.content_keys {
-        let unpacked = unpack_key(&key, content_key).expect("failed to unpack");
+        let unpacked = content_key.unpack(&key).expect("failed to unpack");
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)
@@ -21,7 +20,7 @@ pub async fn run(client: &reqwest::Client, content_id: String, market: String, c
             .unwrap();
         let uuid_buf = uuid.to_bytes_le();
         file.write_all(&uuid_buf).await.unwrap();
-        file.write_all(&unpacked).await.unwrap();
+        file.write_all(&*unpacked).await.unwrap();
         file.flush().await.unwrap();
     }
 }

--- a/xodus-cli/src/license.rs
+++ b/xodus-cli/src/license.rs
@@ -1,6 +1,6 @@
 use crate::{device, user};
 use xodus::{
-    licensing::splicense::SPLicense,
+    licensing::splicense::{DeviceKey, SPLicense},
     models::{live::ExchangeUserTokenOutcome, secrets::Token, soap},
 };
 
@@ -8,7 +8,7 @@ pub async fn get_license(
     client: &reqwest::Client,
     content_id: String,
     market: String,
-) -> std::result::Result<([u8; 16], xodus::licensing::splicense::SPLicense), String> {
+) -> std::result::Result<(DeviceKey, SPLicense), String> {
     let dev_token = device::get_device_token().unwrap();
     let Token::Legacy(dev_token) = dev_token else {
         return Err("Invalid STS token".to_string());

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -128,7 +128,7 @@ fn read_vec<R: Read>(mut reader: R, len: usize) -> io::Result<Vec<u8>> {
 }
 
 #[derive(Debug, Error)]
-pub enum DecodeError {
+pub enum SPLicenseDecodeError {
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),
 
@@ -137,9 +137,9 @@ pub enum DecodeError {
 }
 
 #[derive(Debug, Error)]
-pub enum ParseError {
+pub enum SPLicenseParseError {
     #[error("SPLicense decode error: {0}")]
-    DecodeError(#[from] DecodeError),
+    DecodeError(#[from] SPLicenseDecodeError),
 
     #[error("could not decode base64 string: {0}")]
     PayloadLengthMismatch(#[from] base64::DecodeError),
@@ -149,7 +149,7 @@ impl SPLicense {
     /// Merges a tag-length-value from the `reader` into this [`SPLicense`].
     ///
     /// Returns None if there are none TLVs left in the reader.
-    fn merge_tlv<R: Read>(&mut self, mut reader: R) -> Result<Option<()>, DecodeError> {
+    fn merge_tlv<R: Read>(&mut self, mut reader: R) -> Result<Option<()>, SPLicenseDecodeError> {
         let mut buffer = [0u8; 4];
 
         // Doesn't use read_u32 to allow checking for EOF without error
@@ -270,7 +270,7 @@ impl SPLicense {
 
         // Ensure the number of bytes read is exactly `size`
         if reader.limit() != 0 {
-            return Err(DecodeError::PayloadLengthMismatch {
+            return Err(SPLicenseDecodeError::PayloadLengthMismatch {
                 expected: size,
                 read: size - reader.limit() as usize,
             });
@@ -279,7 +279,7 @@ impl SPLicense {
         Ok(Some(()))
     }
 
-    pub fn decode<R: Read>(mut reader: R) -> Result<Self, DecodeError> {
+    pub fn decode<R: Read>(mut reader: R) -> Result<Self, SPLicenseDecodeError> {
         // Decode the header
         let _header: [u8; 4] = read_array(&mut reader)?;
         let _offset = read_u32(&mut reader)?;
@@ -293,7 +293,7 @@ impl SPLicense {
         Ok(license)
     }
 
-    pub fn parse_base64(string: String) -> Result<SPLicense, ParseError> {
+    pub fn parse_base64(string: String) -> Result<SPLicense, SPLicenseParseError> {
         let data = BASE64_STANDARD.decode(string)?;
         Ok(SPLicense::decode(&*data)?)
     }

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -99,6 +99,9 @@ pub struct EncryptedDeviceKey {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
+pub struct DeviceKey([u8; 16]);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PackedContentKey([u8; 40]);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ContentKey([u8; 32]);
@@ -311,7 +314,7 @@ impl EncryptedDeviceKey {
         transmute!(key)
     }
 
-    pub fn derive_device_key(&self) -> [u8; 16] {
+    pub fn derive_device_key(&self) -> DeviceKey {
         assert!(self.version == 4);
 
         let decryption_key = self.decryption_key();
@@ -323,7 +326,15 @@ impl EncryptedDeviceKey {
         // Sanity check: the decrypted device key must be equal to the decryption key
         assert_eq!(device_key, decryption_key);
 
-        device_key.0
+        DeviceKey(device_key.0)
+    }
+}
+
+impl Deref for DeviceKey {
+    type Target = [u8; 16];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -332,7 +343,7 @@ impl EncryptedDeviceKey {
 pub struct ContentKeyAuthenticationFailed;
 
 impl PackedContentKey {
-    pub fn unpack(&self, key: &[u8; 16]) -> Result<ContentKey, ContentKeyAuthenticationFailed> {
+    pub fn unpack(&self, key: &DeviceKey) -> Result<ContentKey, ContentKeyAuthenticationFailed> {
         let packer = aes_keywrap::Aes128KeyWrapAligned::new(key);
 
         match packer.decapsulate(&self.0) {

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::{collections::HashMap, io, io::Read};
+use std::{collections::HashMap, io, io::Read, ops::Deref};
 
 use aes::cipher::{BlockCipherDecrypt, KeyInit};
 use base64::prelude::*;
@@ -75,7 +75,7 @@ pub struct SPLicense {
     pub signature_block: Vec<u8>,
     pub clep_sign_state: Vec<u8>,
     pub encrypted_device_key: Option<Box<EncryptedDeviceKey>>,
-    pub content_keys: HashMap<uuid::Uuid, Vec<u8>>,
+    pub content_keys: HashMap<uuid::Uuid, PackedContentKey>,
     pub keyholder_public_key: Vec<u8>,
     pub keyholder_policies: Vec<u8>,
     pub license_policies: Vec<u8>,
@@ -97,6 +97,11 @@ pub struct EncryptedDeviceKey {
     device_key: [u8; 16],
     _unknown2: [u8; 3562],
 }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PackedContentKey([u8; 40]);
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ContentKey([u8; 32]);
 
 fn read_array<const N: usize, R: Read>(mut reader: R) -> io::Result<[u8; N]> {
     let mut buf = [0u8; N];
@@ -197,14 +202,15 @@ impl SPLicense {
 
                 while offset < size {
                     let id_len = read_u16(&mut reader)? as usize;
-                    let key_len = read_u16(&mut reader)? as usize;
+                    // key_len is always 40
+                    let _key_len = read_u16(&mut reader)? as usize;
 
                     let key_id = read_uuid(&mut reader)?;
                     let _unknown = read_vec(&mut reader, id_len - 16)?;
-                    let key = read_vec(&mut reader, key_len)?;
+                    let key = PackedContentKey(read_array(&mut reader)?);
 
                     self.content_keys.insert(key_id, key);
-                    offset += 4 + id_len + key_len;
+                    offset += 4 + id_len + 40;
                 }
             }
             Ok(BlockId::ClepSignState) => {
@@ -321,10 +327,38 @@ impl EncryptedDeviceKey {
     }
 }
 
-pub fn unpack_key(
-    key: &[u8; 16],
-    content_key: Vec<u8>,
-) -> Result<Vec<u8>, aes_keywrap::KeywrapError> {
-    let packer = aes_keywrap::Aes128KeyWrapAligned::new(key);
-    packer.decapsulate(&content_key)
+#[derive(Debug, Error)]
+#[error("the ciphertext couldn't be authenticated")]
+pub struct ContentKeyAuthenticationFailed;
+
+impl PackedContentKey {
+    pub fn unpack(&self, key: &[u8; 16]) -> Result<ContentKey, ContentKeyAuthenticationFailed> {
+        let packer = aes_keywrap::Aes128KeyWrapAligned::new(key);
+
+        match packer.decapsulate(&self.0) {
+            Ok(unpaked) => Ok(ContentKey(unpaked.try_into().unwrap())),
+
+            // These errors do not make sense for decapsulate
+            Err(aes_keywrap::KeywrapError::InvalidExpectedLen)
+            | Err(aes_keywrap::KeywrapError::Unpadded) => unreachable!(),
+
+            // The input is always 40 bytes, so these errors are not possible
+            Err(aes_keywrap::KeywrapError::NotAligned)
+            | Err(aes_keywrap::KeywrapError::TooSmall)
+            | Err(aes_keywrap::KeywrapError::TooBig) => unreachable!(),
+
+            // The only possible error is a failure in the authentication of the key
+            Err(aes_keywrap::KeywrapError::AuthenticationFailed) => {
+                Err(ContentKeyAuthenticationFailed)
+            }
+        }
+    }
+}
+
+impl Deref for ContentKey {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }

--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -5,6 +5,8 @@ use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 
 use std::io::{Read, Seek, SeekFrom};
 
+use crate::licensing::splicense::ContentKey;
+
 const PAGE_SIZE: usize = 0x1000;
 
 pub trait PageSource: Read + Seek {}
@@ -37,7 +39,7 @@ impl<R: PageSource> SectionReader<R> {
         section_length: u64,
         header_id: u32,
         vduid: [u8; 8],
-        full_key: [u8; 32],
+        full_key: ContentKey,
         data_units: Option<Vec<u32>>,
     ) -> Self {
         let mut tweak_key = [0u8; 16];

--- a/xodus/src/xvd/utils.rs
+++ b/xodus/src/xvd/utils.rs
@@ -10,6 +10,7 @@ use tokio::{
 };
 use zerocopy::transmute;
 
+use crate::licensing::splicense::ContentKey;
 use crate::xvd::crypt::SectionReader;
 use crate::xvd::math::{
     bytes_to_pages, calculate_hash_block_num_for_block_num, offset_to_page_number,
@@ -20,7 +21,7 @@ use crate::{
 };
 
 struct XvdEncryptionInfo {
-    full_key: [u8; 32],
+    full_key: ContentKey,
     encrypted_sections: Vec<EncryptedSectionInfo>,
 }
 
@@ -399,7 +400,7 @@ pub fn unpack_file(
     xvd: XvdFile,
     path: String,
     destination: String,
-    full_key: [u8; 32],
+    full_key: ContentKey,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sfile = std::fs::File::open(path)?;
     let block_size = 4096; //xvd.header.block_size;

--- a/xodus/src/xvd/utils.rs
+++ b/xodus/src/xvd/utils.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::io::{Error, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
@@ -18,10 +19,19 @@ use crate::{
     xvd::math::page_number_to_offset,
 };
 
-#[derive(Debug)]
 struct XvdEncryptionInfo {
     full_key: [u8; 32],
     encrypted_sections: Vec<EncryptedSectionInfo>,
+}
+
+// The gpt crate requires the device to implement Debug,
+// but the content key must not be debuged
+impl Debug for XvdEncryptionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("XvdEncryptionInfo")
+            .field("encrypted_sections", &self.encrypted_sections)
+            .finish_non_exhaustive() // prints ", .." to signal redacted fields
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Add three new newtype structs to the `SPLicense` module: `PackedContentKey`, `ContentKey` and `DeviceKey`. Those structs are now used instead of the raw u8 arrays.

The `SPLicense` parsing supposes that the packed key is 40 bytes and the content key is 32 bytes.

Also, stop printing the content key in `XvdEncryptionInfo`'s Debug implementation.