### PR TITLE
XVD: `decrypt_page_xts` optimization

### DIFF
--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -3,6 +3,7 @@ use crate::models::xvd::{PAGE_SIZE, XvcRegionId};
 use crate::xvd::math::gf_mul_x;
 
 use std::io::{self, Read, Seek, SeekFrom};
+use std::iter;
 
 use aes::Aes128;
 use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
@@ -163,9 +164,10 @@ fn decrypt_page_xts(
     // XTS requires the data length to be a multiple of the block size (16 bytes).
     const { assert!(PAGE_SIZE.is_multiple_of(16)) };
 
-    let mut tweak = tweak.encrypt(tweak_cipher);
+    // Every tweak in the iterator is calculated by applying `gf_mul_x` to the previous one.
+    let tweaks = iter::successors(Some(tweak.encrypt(tweak_cipher)), |t| Some(gf_mul_x(*t)));
 
-    for block in page.as_chunks_mut::<16>().0 {
+    for (block, tweak) in page.as_chunks_mut::<16>().0.iter_mut().zip(tweaks) {
         let mut out = u128::from_le_bytes(*block);
 
         out ^= tweak;
@@ -173,7 +175,6 @@ fn decrypt_page_xts(
         out ^= tweak;
 
         *block = out.to_le_bytes();
-        tweak = gf_mul_x(tweak);
     }
 
     page

--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -133,18 +133,13 @@ impl<R: PageSource> SectionReader<R> {
             None => page_in_section as u32,
         });
 
-        let mut ciphertext = [0u8; PAGE_SIZE];
+        let mut page = [0u8; PAGE_SIZE];
         self.inner.seek(SeekFrom::Start(file_offset))?;
-        self.inner.read_exact(&mut ciphertext)?;
+        self.inner.read_exact(&mut page)?;
 
-        let plaintext = decrypt_page_xts(
-            ciphertext,
-            self.tweak,
-            &self.tweak_cipher,
-            &self.data_cipher,
-        );
+        decrypt_page_xts(&mut page, self.tweak, &self.tweak_cipher, &self.data_cipher);
 
-        self.cached_page_plaintext.copy_from_slice(&plaintext);
+        self.cached_page_plaintext = page;
         self.cached_page_index = Some(page_in_section);
         Ok(())
     }
@@ -156,11 +151,11 @@ impl<R: PageSource> SectionReader<R> {
 /// to decrypt the data. Each 16-byte block is decrypted as `P = AES_dec(C ⊕ T) ⊕ T`,
 /// where `T` is the AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
 fn decrypt_page_xts(
-    mut page: [u8; PAGE_SIZE],
+    page: &mut [u8; PAGE_SIZE],
     tweak: Tweak,
     tweak_cipher: &Aes128,
     data_cipher: &Aes128,
-) -> [u8; PAGE_SIZE] {
+) {
     // XTS requires the data length to be a multiple of the block size (16 bytes).
     const { assert!(PAGE_SIZE.is_multiple_of(16)) };
 
@@ -176,8 +171,6 @@ fn decrypt_page_xts(
 
         *block = out.to_le_bytes();
     }
-
-    page
 }
 
 #[inline]

--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -156,6 +156,43 @@ fn decrypt_page_xts(
     tweak_cipher: &Aes128,
     data_cipher: &Aes128,
 ) {
+    transform_page_xts(page, tweak, tweak_cipher, |block| {
+        data_cipher.decrypt_block(block);
+    });
+}
+
+/// Encrypts a page using XTS-AES (IEEE 1619-2007).
+///
+/// XTS-AES uses two keys: a tweak key to derive a per-page tweak, and a data key
+/// to encrypt the data. Each 16-byte block is encrypted as `C = AES_enc(P ⊕ T) ⊕ T`,
+/// where `T` is the AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
+fn encrypt_page_xts(
+    page: &mut [u8; PAGE_SIZE],
+    tweak: Tweak,
+    tweak_cipher: &Aes128,
+    data_cipher: &Aes128,
+) {
+    transform_page_xts(page, tweak, tweak_cipher, |block| {
+        data_cipher.encrypt_block(block);
+    });
+}
+
+/// Transforms a page using XTS-AES (IEEE 1619-2007).
+///
+/// Each 16-byte block is transformed as `out = transform(in ⊕ T) ⊕ T`, where `T` is the
+/// AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
+///
+/// The `transform` function is called with each block after the tweak is applied, and should
+/// perform either AES encryption or decryption.
+#[inline]
+fn transform_page_xts<F>(
+    page: &mut [u8; PAGE_SIZE],
+    tweak: Tweak,
+    tweak_cipher: &Aes128,
+    transform: F,
+) where
+    F: Fn(&mut aes::Block),
+{
     // XTS requires the data length to be a multiple of the block size (16 bytes).
     const { assert!(PAGE_SIZE.is_multiple_of(16)) };
 
@@ -166,16 +203,13 @@ fn decrypt_page_xts(
         let mut out = u128::from_le_bytes(*block);
 
         out ^= tweak;
-        out = aes_decrypt(data_cipher, out);
+        out = {
+            let mut buf = aes::Block::from(out.to_le_bytes());
+            transform(&mut buf);
+            u128::from_le_bytes(buf.0)
+        };
         out ^= tweak;
 
         *block = out.to_le_bytes();
     }
-}
-
-#[inline]
-fn aes_decrypt(cipher: &Aes128, block: u128) -> u128 {
-    let mut block = aes::Block::from(block.to_le_bytes());
-    cipher.decrypt_block(&mut block);
-    u128::from_le_bytes(block.0)
 }

--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -12,7 +12,7 @@ pub trait PageSource: Read + Seek {}
 impl<T: Read + Seek> PageSource for T {}
 
 #[derive(Clone, Copy)]
-struct Tweak([u8; 16]);
+pub struct Tweak([u8; 16]);
 
 impl Tweak {
     pub fn new(data_unit: u32, header_id: XvcRegionId, vduid: [u8; 8]) -> Self {
@@ -150,7 +150,7 @@ impl<R: PageSource> SectionReader<R> {
 /// XTS-AES uses two keys: a tweak key to derive a per-page tweak, and a data key
 /// to decrypt the data. Each 16-byte block is decrypted as `P = AES_dec(C ⊕ T) ⊕ T`,
 /// where `T` is the AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
-fn decrypt_page_xts(
+pub fn decrypt_page_xts(
     page: &mut [u8; PAGE_SIZE],
     tweak: Tweak,
     tweak_cipher: &Aes128,
@@ -167,7 +167,7 @@ fn decrypt_page_xts(
 /// to encrypt the data. Each 16-byte block is encrypted as `C = AES_enc(P ⊕ T) ⊕ T`,
 /// where `T` is the AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
 #[expect(dead_code)]
-fn encrypt_page_xts(
+pub fn encrypt_page_xts(
     page: &mut [u8; PAGE_SIZE],
     tweak: Tweak,
     tweak_cipher: &Aes128,

--- a/xodus/src/xvd/crypt.rs
+++ b/xodus/src/xvd/crypt.rs
@@ -166,6 +166,7 @@ fn decrypt_page_xts(
 /// XTS-AES uses two keys: a tweak key to derive a per-page tweak, and a data key
 /// to encrypt the data. Each 16-byte block is encrypted as `C = AES_enc(P ⊕ T) ⊕ T`,
 /// where `T` is the AES-encrypted tweak, advanced by one GF(2¹²⁸) multiplication per block.
+#[expect(dead_code)]
 fn encrypt_page_xts(
     page: &mut [u8; PAGE_SIZE],
     tweak: Tweak,


### PR DESCRIPTION
Continues #46

Optimize `decrypt_page_xts` a bit further by creating an iterator over the tweaks, and then zipping both the block and the tweak into the for loop. This way, no mutable state from outside the loop is needed in the iteration, making the code more readable (in my opinion) and simpler for LLVM to optimize.

By computing the next tweak before the AES decryption, and due to some complicated CPU stuff that I don't deeply understand, the tweak is calculated at the same time as the AES decryption, making the function a bit faster (around 8%).

I tried other versions of the function, like decrypting multiple AES blocks in parallel in the same CPU core or precomputing all tweaks into an array, but no version was faster than the one in this PR.

Also, the `decrypt_page_xts` function now receives the page by mutable reference instead of receiving it by value because it was around 12% faster in benchmarks. I wasn't able to check, however, whether that optimization was already being done automatically by LLVM in Xodus.

Benchmark:
```
hyperfine --warmup 10 ./bench1-1 ./bench1-2
Benchmark 1: ./bench1-1
  Time (mean ± σ):     464.7 ms ±   1.3 ms    [User: 461.9 ms, System: 1.3 ms]
  Range (min … max):   463.3 ms … 467.3 ms    10 runs
 
Benchmark 2: ./bench1-2
  Time (mean ± σ):     430.7 ms ±   3.8 ms    [User: 428.5 ms, System: 0.8 ms]
  Range (min … max):   426.7 ms … 439.2 ms    10 runs
 
Summary
  ./bench1-2 ran
    1.08 ± 0.01 times faster than ./bench1-1
```