### PR TITLE
xvd: extract: speed up by avoiding data unit clone

### DIFF
--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -35,7 +35,7 @@ impl Tweak {
     }
 }
 
-pub struct SectionReader<R,'t> {
+pub struct SectionReader<'t, R> {
     inner: R,
     section_offset: u64,
     section_length: u64,
@@ -54,7 +54,7 @@ pub struct SectionReader<R,'t> {
     cached_page_plaintext: [u8; PAGE_SIZE],
 }
 
-impl<R: PageSource, 't> SectionReader<R> {
+impl<'t, R: PageSource> SectionReader<R> {
     pub fn new(
         inner: R,
         section_offset: u64,

--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -3,6 +3,7 @@ use crate::models::xvd::{PAGE_SIZE, XvcRegionId};
 
 use std::io::{self, Read, Seek, SeekFrom};
 use std::iter;
+use std::rc::Rc;
 
 use aes::Aes128;
 use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
@@ -47,7 +48,7 @@ pub struct SectionReader<R> {
 
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
-    data_units: Option<Vec<u32>>,
+    data_units: Option<Rc<[u32]>>,
 
     // simplest useful cache
     cached_page_index: Option<u64>,
@@ -62,7 +63,7 @@ impl<R: PageSource> SectionReader<R> {
         header_id: XvcRegionId,
         vduid: [u8; 8],
         full_key: [u8; 32],
-        data_units: Option<Vec<u32>>,
+        data_units: Option<Rc<[u32]>>,
     ) -> Self {
         let mut tweak_key = [0u8; 16];
         let mut data_key = [0u8; 16];

--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -3,7 +3,6 @@ use crate::models::xvd::{PAGE_SIZE, XvcRegionId};
 
 use std::io::{self, Read, Seek, SeekFrom};
 use std::iter;
-use std::rc::Rc;
 
 use aes::Aes128;
 use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
@@ -36,7 +35,7 @@ impl Tweak {
     }
 }
 
-pub struct SectionReader<R> {
+pub struct SectionReader<R,'t> {
     inner: R,
     section_offset: u64,
     section_length: u64,
@@ -48,14 +47,14 @@ pub struct SectionReader<R> {
 
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
-    data_units: Option<Rc<[u32]>>,
+    data_units: Option<&'t Vec<u32>>,
 
     // simplest useful cache
     cached_page_index: Option<u64>,
     cached_page_plaintext: [u8; PAGE_SIZE],
 }
 
-impl<R: PageSource> SectionReader<R> {
+impl<R: PageSource, 't> SectionReader<R> {
     pub fn new(
         inner: R,
         section_offset: u64,
@@ -63,7 +62,7 @@ impl<R: PageSource> SectionReader<R> {
         header_id: XvcRegionId,
         vduid: [u8; 8],
         full_key: [u8; 32],
-        data_units: Option<Rc<[u32]>>,
+        data_units: Option<&'t Vec<u32>>,
     ) -> Self {
         let mut tweak_key = [0u8; 16];
         let mut data_key = [0u8; 16];

--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -47,7 +47,7 @@ pub struct SectionReader<'t, R> {
 
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
-    data_units: Option<&'t Vec<u32>>,
+    data_units: Option<&'t [u32]>,
 
     // simplest useful cache
     cached_page_index: Option<u64>,
@@ -62,7 +62,7 @@ impl<'t, R: PageSource> SectionReader<'t, R> {
         header_id: XvcRegionId,
         vduid: [u8; 8],
         full_key: [u8; 32],
-        data_units: Option<&'t Vec<u32>>,
+        data_units: Option<&'t [u32]>,
     ) -> Self {
         let mut tweak_key = [0u8; 16];
         let mut data_key = [0u8; 16];

--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -54,7 +54,7 @@ pub struct SectionReader<'t, R> {
     cached_page_plaintext: [u8; PAGE_SIZE],
 }
 
-impl<'t, R: PageSource> SectionReader<R> {
+impl<'t, R: PageSource> SectionReader<'t, R> {
     pub fn new(
         inner: R,
         section_offset: u64,

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::task::block_in_place;
 use tokio::time::{sleep, timeout};
@@ -403,7 +404,7 @@ pub struct EncryptedSectionInfo {
 
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
-    data_units: Option<Vec<u32>>,
+    data_units: Option<Rc<[u32]>>,
     first_segment_index: u32,
     data_hashs: Vec<[u8; 20]>,
 }
@@ -545,7 +546,7 @@ impl XvdFile {
                 section_length: h.length,
                 header_id: h.region_id,
                 vduid: xvd_header.vduid.to_bytes_le()[..8].try_into().unwrap(),
-                data_units: Some(data_units),
+                data_units: Some(data_units.into()),
                 first_segment_index: h.first_segment_index,
                 data_hashs,
             });

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::task::block_in_place;
 use tokio::time::{sleep, timeout};
@@ -259,7 +258,7 @@ impl<R: Read + Seek> Read for XvdStream<R> {
                         s.header_id,
                         s.vduid,
                         encryption_info.full_key,
-                        s.data_units.clone(),
+                        s.data_units.as_ref(),
                     );
                     return reader
                         .read_at(
@@ -404,7 +403,7 @@ pub struct EncryptedSectionInfo {
 
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
-    data_units: Option<Rc<[u32]>>,
+    data_units: Option<Vec<u32>>,
     first_segment_index: u32,
     data_hashs: Vec<[u8; 20]>,
 }
@@ -546,7 +545,7 @@ impl XvdFile {
                 section_length: h.length,
                 header_id: h.region_id,
                 vduid: xvd_header.vduid.to_bytes_le()[..8].try_into().unwrap(),
-                data_units: Some(data_units.into()),
+                data_units: Some(data_units),
                 first_segment_index: h.first_segment_index,
                 data_hashs,
             });

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -258,7 +258,7 @@ impl<R: Read + Seek> Read for XvdStream<R> {
                         s.header_id,
                         s.vduid,
                         encryption_info.full_key,
-                        s.data_units.as_ref(),
+                        s.data_units.as_deref(),
                     );
                     return reader
                         .read_at(


### PR DESCRIPTION
Extracting a MSIXVC file was slow because the large `data_units` vector was being cloned constantly. Replace the `Vec` clone with an `Rc` reference counted clone, which is much faster.

This is kind of a hack, it's not bad but in the end I would like to avoid cloning the data units at all.

Benchmarks:
```
Benchmark 1: ./xodus-old extract Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe.msixvc Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe/
  Time (mean ± σ):     10.054 s ±  0.147 s    [User: 6.097 s, System: 2.338 s]
  Range (min … max):    9.829 s … 10.283 s    10 runs
 
Benchmark 2: ./xodus-new extract Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe.msixvc Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe/
  Time (mean ± σ):      5.982 s ±  0.673 s    [User: 0.836 s, System: 1.939 s]
  Range (min … max):    4.925 s …  6.809 s    10 runs
 
Summary
  ./xodus-new extract Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe.msixvc Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe/ ran
    1.68 ± 0.19 times faster than ./xodus-old extract Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe.msixvc Microsoft.MinecraftUWP_1.26.3005.0_x64__8wekyb3d8bbwe/
```