### PR TITLE
xvd: add parse invariants

### DIFF
--- a/msixvc/src/crypt.rs
+++ b/msixvc/src/crypt.rs
@@ -7,9 +7,6 @@ use std::iter;
 use aes::Aes128;
 use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 
-pub trait PageSource: Read + Seek {}
-impl<T: Read + Seek> PageSource for T {}
-
 #[derive(Clone, Copy)]
 pub struct Tweak([u8; 16]);
 
@@ -54,7 +51,7 @@ pub struct SectionReader<'t, R> {
     cached_page_plaintext: [u8; PAGE_SIZE],
 }
 
-impl<'t, R: PageSource> SectionReader<'t, R> {
+impl<'t, R: Read + Seek> SectionReader<'t, R> {
     pub fn new(
         inner: R,
         section_offset: u64,
@@ -82,7 +79,7 @@ impl<'t, R: PageSource> SectionReader<'t, R> {
         }
     }
 
-    pub fn read_at(&mut self, offset_in_section: u64, out: &mut [u8]) -> io::Result<()> {
+    pub fn read_at(&mut self, offset_in_section: u64, mut out: &mut [u8]) -> io::Result<()> {
         let end = offset_in_section
             .checked_add(out.len() as u64)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "range overflow"))?;
@@ -94,22 +91,19 @@ impl<'t, R: PageSource> SectionReader<'t, R> {
             ));
         }
 
-        let mut remaining = out.len();
-        let mut dst_off = 0usize;
         let mut cur_off = offset_in_section;
 
-        while remaining > 0 {
+        while !out.is_empty() {
             let page_in_section = cur_off / PAGE_SIZE as u64;
             let in_page = (cur_off % PAGE_SIZE as u64) as usize;
-            let copy_len = remaining.min(PAGE_SIZE - in_page);
+            let copy_len = std::cmp::min(out.len(), PAGE_SIZE - in_page);
 
             self.ensure_page_decrypted(page_in_section)?;
-            out[dst_off..dst_off + copy_len]
+            out[..copy_len]
                 .copy_from_slice(&self.cached_page_plaintext[in_page..in_page + copy_len]);
 
             cur_off += copy_len as u64;
-            dst_off += copy_len;
-            remaining -= copy_len;
+            out = &mut out[copy_len..];
         }
 
         Ok(())

--- a/msixvc/src/models/xsp/structs/parsed.rs
+++ b/msixvc/src/models/xsp/structs/parsed.rs
@@ -14,14 +14,14 @@ pub struct XspHeader {
     pub upgrade_to_version: Version,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum XspHeaderParseError {
-    #[error(r#"invalid magic: expected "MS-XPFM ": {0:?}"#)]
-    InvalidMagic([u8; 8]),
-}
-
 impl XspHeader {
     const MAGIC: [u8; 8] = *b"MS-XPFM ";
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum XspHeaderParseError {
+    #[error(r#"invalid magic: expected {magic:?}, got {0:?}"#, magic = XspHeader::MAGIC)]
+    InvalidMagic([u8; 8]),
 }
 
 impl TryFrom<raw::XspHeader> for XspHeader {

--- a/msixvc/src/models/xvd/structs/parsed.rs
+++ b/msixvc/src/models/xvd/structs/parsed.rs
@@ -65,7 +65,7 @@ impl XvdHeader {
 
 #[derive(thiserror::Error, Debug)]
 pub enum XvdHeaderParseError {
-    #[error(r#"invalid magic: expected "msft-xvd", got {0:?}"#)]
+    #[error(r#"invalid magic: expected {magic:?}, got {0:?}"#, magic = XvdHeader::MAGIC)]
     InvalidMagic([u8; 8]),
 
     #[error("invalid xvd type: {0}")]
@@ -402,7 +402,7 @@ impl XvdSegmentMetadataHeader {
 
 #[derive(thiserror::Error, Debug)]
 pub enum XvdSegmentMetadataHeaderParseError {
-    #[error(r#"invalid magic: expected "XFP ", got {0:?}"#)]
+    #[error(r#"invalid magic: expected {magic:?}, got {0:?}"#, magic = XvdSegmentMetadataHeader::MAGIC)]
     InvalidMagic([u8; 4]),
 }
 

--- a/msixvc/src/models/xvd/structs/parsed.rs
+++ b/msixvc/src/models/xvd/structs/parsed.rs
@@ -3,7 +3,7 @@ use crate::common::microsoft_filetime;
 use crate::math::{bytes_to_pages, calculate_number_of_hash_pages, page_number_to_offset};
 use crate::models::common::Version;
 use crate::models::xvd::constants::{
-    LEGACY_SECTOR_SIZE, SECTOR_SIZE, XVD_HEADER_INCL_SIGNATURE_SIZE,
+    LEGACY_SECTOR_SIZE, PAGE_SIZE, SECTOR_SIZE, XVD_HEADER_INCL_SIGNATURE_SIZE,
 };
 use crate::models::xvd::enums::{XvcRegionId, XvdContentType, XvdType};
 use crate::models::xvd::flags::{
@@ -276,23 +276,47 @@ pub struct XvcRegionHeader {
     pub flags: XvcRegionFlags,
     pub first_segment_index: u32,
     pub description: [u16; 0x20], // UTF-16
+    // Multiple of PAGE_SIZE
     pub offset: u64,
+    // Multiple of PAGE_SIZE
     pub length: u64,
     pub hash: u64,
 }
 
-impl From<raw::XvcRegionHeader> for XvcRegionHeader {
-    fn from(value: raw::XvcRegionHeader) -> Self {
-        Self {
+#[derive(thiserror::Error, Debug)]
+pub enum XvcRegionHeaderParseError {
+    #[error("invalid offset {0}: must be a multiple of page size ({PAGE_SIZE})")]
+    InvalidOffset(u64),
+
+    #[error("invalid length {0}: must be a multiple of page size ({PAGE_SIZE})")]
+    InvalidLength(u64),
+}
+
+impl TryFrom<raw::XvcRegionHeader> for XvcRegionHeader {
+    type Error = XvcRegionHeaderParseError;
+
+    fn try_from(value: raw::XvcRegionHeader) -> Result<Self, Self::Error> {
+        let offset = value.offset.get();
+        let length = value.length.get();
+
+        if !offset.is_multiple_of(PAGE_SIZE as u64) {
+            return Err(XvcRegionHeaderParseError::InvalidOffset(offset));
+        }
+
+        if !length.is_multiple_of(PAGE_SIZE as u64) {
+            return Err(XvcRegionHeaderParseError::InvalidLength(length));
+        }
+
+        Ok(Self {
             region_id: value.region_id.get().into(),
             key_id: XvcKeyId::new(value.key_id.get()),
             flags: XvcRegionFlags::from_bits_retain(value.flags.get()),
             first_segment_index: value.first_segment_index.get(),
             description: value.description.map(|n| n.get()),
-            offset: value.offset.get(),
-            length: value.length.get(),
+            offset,
+            length,
             hash: value.hash.get(),
-        }
+        })
     }
 }
 

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -477,7 +477,7 @@ impl XvdFile {
 
             if xvc_info.version >= 1 {
                 for _ in 0..region_count {
-                    let Ok(region_header) = read_struct!(XvcRegionHeader, file);
+                    let region_header = read_struct!(XvcRegionHeader, file)?;
                     region_headers.push(region_header);
                 }
             }


### PR DESCRIPTION
This PR contains 3 changes:
- Make sure that the offset and length of each `XvdRegionHeader` is a multiple of `PAGE_SIZE`.
- Don't hardcode the magic values in the parse error messages.
- Simplify the `msixvc::crypt::read_at` function by modifying the out buffer directly.