### PR TITLE
msixvc: pass Reader by value

### DIFF
--- a/msixvc/src/xsp.rs
+++ b/msixvc/src/xsp.rs
@@ -7,8 +7,9 @@ pub struct XspFile {
     pub header: XspHeader,
     pub entries: Vec<XspPatchRecord>,
 }
+
 impl XspFile {
-    pub async fn parse_file<Reader>(file: &mut Reader) -> Result<Self, Box<dyn std::error::Error>>
+    pub async fn parse_file<Reader>(file: Reader) -> Result<Self, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -454,7 +454,7 @@ impl XvdFile {
         Self::parse(&mut file).await
     }
 
-    pub async fn parse<Reader>(file: &mut Reader) -> Result<Self, Box<dyn std::error::Error>>
+    pub async fn parse<Reader>(mut file: Reader) -> Result<Self, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {
@@ -560,7 +560,7 @@ impl XvdFile {
 
     pub async fn parse_user_package_files<Reader>(
         &self,
-        file: &mut Reader,
+        mut file: Reader,
     ) -> Result<HashMap<String, UserPackageFile>, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
@@ -602,14 +602,13 @@ impl XvdFile {
 
     pub async fn parse_segment_metadata<Reader>(
         &mut self,
-        file: &mut Reader,
+        file: Reader,
         segment_metadata: &UserPackageFile,
     ) -> Result<HashMap<String, SegmentFile>, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {
-        let mut file: BufReader<&mut Reader> =
-            BufReader::with_capacity(segment_metadata.length as usize, file);
+        let mut file = BufReader::with_capacity(segment_metadata.length as usize, file);
         file.seek(SeekFrom::Start(segment_metadata.offset)).await?;
         let segment_header: XvdSegmentMetadataHeader =
             read_struct!(XvdSegmentMetadataHeader, file)?;
@@ -734,7 +733,7 @@ impl XvdFile {
 
     pub async fn parse_ntfs_segment_metadata<Reader>(
         &self,
-        file: &mut Reader,
+        file: Reader,
     ) -> Result<HashMap<String, SegmentFile>, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -601,7 +601,7 @@ impl XvdFile {
     }
 
     pub async fn parse_segment_metadata<Reader>(
-        &mut self,
+        &self,
         file: Reader,
         segment_metadata: &UserPackageFile,
     ) -> Result<HashMap<String, SegmentFile>, Box<dyn std::error::Error>>

--- a/xodus-cli/src/commands/streaming.rs
+++ b/xodus-cli/src/commands/streaming.rs
@@ -208,20 +208,20 @@ pub async fn run(
         rfiles = sfiles;
     }
 
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .read(true)
         .open(final_path.to_owned())
         .await
         .ok();
 
-    if let Some(file) = &mut file {
-        let mut xvd = XvdFile::parse(file).await.expect("no err");
+    if let Some(mut file) = file {
+        let mut xvd = XvdFile::parse(&mut file).await.expect("no err");
 
         if try_skip_ntfs {
-            let files = xvd.parse_user_package_files(file).await.expect("ok");
+            let files = xvd.parse_user_package_files(&mut file).await.expect("ok");
             for (k, v) in &files {
                 if k == "SegmentMetadata.bin" {
-                    let sfiles = xvd.parse_segment_metadata(file, v).await.expect("ok");
+                    let sfiles = xvd.parse_segment_metadata(&mut file, v).await.expect("ok");
                     for (n, sfile) in &sfiles {
                         if sfile.length.div_ceil(PAGE_SIZE as u64) as usize
                             != sfile.data_hashs.len()
@@ -246,7 +246,10 @@ pub async fn run(
         }
 
         if lfiles.is_empty() {
-            let sfiles = xvd.parse_ntfs_segment_metadata(file).await.expect("ok");
+            let sfiles = xvd
+                .parse_ntfs_segment_metadata(&mut file)
+                .await
+                .expect("ok");
             for (n, sfile) in &sfiles {
                 if sfile.length.div_ceil(PAGE_SIZE as u64) as usize != sfile.data_hashs.len() {
                     println!("{}: {} {}", n, sfile.offset, sfile.length);

--- a/xodus-cli/src/commands/streaming.rs
+++ b/xodus-cli/src/commands/streaming.rs
@@ -154,7 +154,7 @@ pub async fn run(
     let mut remote_file = streaming::PrefixCacheFile::new(http_file, l, cache_path.clone())
         .await
         .expect("no err");
-    let mut remote_xvd = XvdFile::parse(&mut remote_file).await.expect("no err");
+    let remote_xvd = XvdFile::parse(&mut remote_file).await.expect("no err");
     let mut rfiles: HashMap<String, SegmentFile> = HashMap::new();
     let mut lfiles: HashMap<String, SegmentFile> = HashMap::new();
 
@@ -215,7 +215,7 @@ pub async fn run(
         .ok();
 
     if let Some(mut file) = file {
-        let mut xvd = XvdFile::parse(&mut file).await.expect("no err");
+        let xvd = XvdFile::parse(&mut file).await.expect("no err");
 
         if try_skip_ntfs {
             let files = xvd.parse_user_package_files(&mut file).await.expect("ok");


### PR DESCRIPTION
It's better to pass readers by value, because a function that accepts `R: Read` can also be called with a `&mut Read`.
See the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value).

Also, `XvdFile::parse_segment_metadata` took `&mut self`, but `self` was not being mutated, so I changed the function signature to receive `&self`.