### PR TITLE
cargo/config.toml: add aes target feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# See https://docs.rs/aes/0.9.1/aes/#supported-backends
+# and https://github.com/xodus-gaming/xodus/pull/60
+
+[target.'cfg(target_arch = "x86_64")']
+rustflags = ["-Ctarget-feature=+aes,+ssse3"]
+
+[target.'cfg(target_arch = "aarch64")']
+rustflags = ["-Ctarget-feature=+aes"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Running xodus-service in debug
 cargo run --bin xodus-service
 ```
 
+> [!TIP]
+> For better performance when decrypting MSIXVC files, enable the `aes` target feature by passing
+> `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3` to cargo build.
+>
+> See https://docs.rs/aes/0.9.1/aes/#x86x86_64-intrinsics-aes-ni-and-vaes for more information.
+>
+> Note that AES-NI is not available on very old CPUs.
+> See https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors for a list of compatible CPUs.
+
 ### CLI Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Xodus aims to bring Xbox PC games to Linux and possibly Mac devices.
 
 **Q: When can I play my Minecraft Bedrock?**  
 While Xodus is quickly maturing, there is still a lot of work to support it from Wine standpoint to provide necessary Xbox Services to games.  
-*TL;DR* soon<sup>tm</sup>
+_TL;DR_ soon<sup>tm</sup>
 
 **Q: How to get involved?**  
 Start by joining our Discord or review any open GitHub issues .
@@ -53,7 +53,7 @@ The project structure is as follows.
 .
 ├── msixvc - [rlib] common rlib crate for utilities for parsing MSIXVC and XSP files
 ├── xodus - [rlib] common rlib crate that contains core xodus functionality, API calls abstractions and utilities
-├── xodus-cli - [bin] CLI currently used for iterating over new xodus features 
+├── xodus-cli - [bin] CLI currently used for iterating over new xodus features
 └── xodus-service - [bin] service process exposing a xodus.sock for IPC communication, it takes care of and xgameruntime.dll integration.
 ```
 
@@ -69,16 +69,19 @@ The project structure is as follows.
 ### Running
 
 Building all crates in release mode
+
 ```bash
 cargo build --release --workspace
 ```
 
 Running cli in debug
+
 ```
 cargo run -- --help
 ```
 
 Running xodus-service in debug
+
 ```
 cargo run --bin xodus-service
 ```
@@ -92,7 +95,7 @@ Commands:
   download   Download msixvc or xsp files fo given game
   license    Dump CIKs for use with XvdTool
   extract    Extract locally stored msixvc file
-  login      
+  login
   streaming  Download and extract the game through streaming algorithm
   help       Print this message or the help of the given subcommand(s)
 
@@ -100,7 +103,6 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 ```
-
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -86,14 +86,13 @@ Running xodus-service in debug
 cargo run --bin xodus-service
 ```
 
-> [!TIP]
-> For better performance when decrypting MSIXVC files, enable the `aes` target feature by passing
-> `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3` to cargo build.
+> [!WARNING]
+> For better performance when decrypting MSIXVC files, the `aes` and `ssse3` features are enabled on `x86_64`,
+> and the `aes` feature is enabled on `aarch64`. This means that the program will crash with an illegal instruction
+> error when running on a CPU which doesn't support those instructions.
 >
-> See https://docs.rs/aes/0.9.1/aes/#x86x86_64-intrinsics-aes-ni-and-vaes for more information.
->
-> Note that AES-NI is not available on very old CPUs.
-> See https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors for a list of compatible CPUs.
+> See https://en.wikipedia.org/wiki/AES_instruction_set for a list of compatible CPUs (every modern processor from
+> 2011 onwards should be supported).
 
 ### CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cargo run --bin xodus-service
 > and the `aes` feature is enabled on `aarch64`. This means that the program will crash with an illegal instruction
 > error when running on a CPU which doesn't support those instructions.
 >
-> See https://en.wikipedia.org/wiki/AES_instruction_set for a list of compatible CPUs (every modern processor from
+> See https://en.wikipedia.org/wiki/AES_instruction_set for a list of compatible CPUs (every processor from
 > 2011 onwards should be supported).
 
 ### CLI Usage


### PR DESCRIPTION
Add a note in the README that decryption of MSIXVC files can be much faster by compiling with the `aes` target feature. See the benchmarks below for more information.

We should compile with the `aes` target feature enabled when releasing compiled binaries. Without it, decryption is slow enough to block the tokio runtime, requiring `spawn_blocking` instead of running inline in an async task.

The main drawback is that the `aes` feature is not available on very old CPUs, but then the decryption would fall back to software, and that is a lot slower, I would say unusable (see the benchmarks).

Edit: enable the features by default by adding them to `.cargo/config.toml`
 
## Benchmarks
Tested on an `AMD Ryzen 5 7600`
```
hyperfine --warmup 2 ./bench-native ./bench-aes ./bench-none ./bench-soft
Benchmark 1: ./bench-native
  Time (mean ± σ):     383.6 ms ±   1.5 ms    [User: 381.7 ms, System: 0.9 ms]
  Range (min … max):   381.3 ms … 386.2 ms    10 runs
 
Benchmark 2: ./bench-aes
  Time (mean ± σ):     439.7 ms ±   4.0 ms    [User: 437.8 ms, System: 0.9 ms]
  Range (min … max):   435.5 ms … 444.2 ms    10 runs
 
Benchmark 3: ./bench-none
  Time (mean ± σ):      4.007 s ±  0.002 s    [User: 3.998 s, System: 0.001 s]
  Range (min … max):    4.004 s …  4.008 s    10 runs
 
Benchmark 4: ./bench-soft
  Time (mean ± σ):     64.137 s ±  0.130 s    [User: 63.988 s, System: 0.001 s]
  Range (min … max):   63.987 s … 64.372 s    10 runs
 
Summary
  ./bench-native ran
    1.15 ± 0.01 times faster than ./bench-aes
   10.45 ± 0.04 times faster than ./bench-none
  167.20 ± 0.72 times faster than ./bench-soft
```

| Benchmark | Compile flags | Time per block | Throughput |
|-----------|---------------|----------------|------------|
| `bench-native` | `-Ctarget-cpu=native` | ~383.6 ns | ~10.4 GiB/s |
| `bench-aes` | `-Ctarget-feature=+aes,+ssse3` | ~439.7 ns | ~9.1 GiB/s |
| `bench-none` | _(none)_ | ~4.0 µs | ~1.0 GiB/s |
| `bench-soft` | software fallback (reference) | ~64.1 µs | ~62.4 MiB/s |